### PR TITLE
Change main capability

### DIFF
--- a/app.php
+++ b/app.php
@@ -36,7 +36,7 @@ final class RUA_App {
 	/**
 	 * Capability to manage restrictions
 	 */
-	const CAPABILITY           = 'edit_users';
+	const CAPABILITY           = 'manage_restrictions';
 
 	const BASE_SCREEN          = 'wprua';
 

--- a/app.php
+++ b/app.php
@@ -15,7 +15,7 @@ final class RUA_App {
 	/**
 	 * Plugin version
 	 */
-	const PLUGIN_VERSION       = '0.15';
+	const PLUGIN_VERSION       = '0.15.1';
 
 	/**
 	 * Prefix for metadata
@@ -413,5 +413,4 @@ final class RUA_App {
 	}
 
 }
-
 //eol

--- a/level.php
+++ b/level.php
@@ -724,11 +724,11 @@ final class RUA_Level_Manager {
 	/**
 	 * Reset user level caps to trigger reload when `user_has_cap` filter is used.
 	 *
-	 * @since  0.15-dev
+	 * @since  0.15.1
 	 * @param  $user_id
 	 */
 	public function reset_user_levels_caps( $user_id ) {
-		unset( $this->user_levels_caps[$user_id] );
+		unset( $this->user_levels_caps[ $user_id ] );
 	}
 
 	/**
@@ -746,5 +746,4 @@ final class RUA_Level_Manager {
 	}
 
 }
-
 //eol


### PR DESCRIPTION
Change the main capability to one that is unique to this plugin: `manage_restrictions`.

- Network: By default only super admins can access.
- Single install: By default only administrators can access.

Can be assigned to any user with a role manager plugin to grant access to RUA settings and access levels.
I've chosen a custom capability so admin's won't have to grant users access to other functionality if they don't want to.

Also updates the version to 0.15.1