### PR TITLE
Fix for the restrict macro when including another page's content

### DIFF
--- a/level.php
+++ b/level.php
@@ -194,7 +194,8 @@ final class RUA_Level_Manager {
 					$content = '';
 				}
 			}
-			if($a['page']) {
+			// Only apply the page content if the user does not have access.
+			if($a['page'] && !$content) {
 				$page = get_post($a['page']);
 				if($page) {
 					setup_postdata($page);


### PR DESCRIPTION
I believe the intended use of the 'page' attribute in the 'restrict' macro was to include the specified page's content when the user did not have access. This is a little fix to make that the case.