### PR TITLE
Prevent window.onbeforeunload dialog popup on load.

### DIFF
--- a/js/suggest-levels.js
+++ b/js/suggest-levels.js
@@ -75,7 +75,7 @@
 			});
 			//select3.5 compat for setting value by id
 			if($elem.data('value')) {
-				$elem.val($elem.data('value').toString().split(',')).trigger('change');
+				$elem.val($elem.data('value').toString().split(',')).trigger('change.select2');
 			}
 		}
 	};


### PR DESCRIPTION
When the menu pages load with RUA activated reloading the page causes a dialog popup because of `trigger('change')`.
Since this is for select2 it's better to change the trigger to `change.select2` which also works find but prevents WP from thinking the form has changed in any way.